### PR TITLE
update buildscript to support building on Java 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,12 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.7'
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.21'
+    id 'com.gtnewhorizons.retrofuturagradle' version '2.0.2'
     id 'net.darkhax.curseforgegradle' version '1.0.14' apply false
     id 'com.modrinth.minotaur' version '2.8.0' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
     id 'com.palantir.git-version' version '3.0.0' apply false
-    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'com.gradleup.shadow' version '9.4.2' apply false
 }
 
 if (verifySettingsGradle()) {
@@ -277,7 +277,9 @@ else {
 }
 
 group = modGroup
-archivesBaseName = modArchivesBaseName
+base {
+    archivesName = modArchivesBaseName
+}
 
 minecraft {
     mcVersion = minecraftVersion

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,9 +3,7 @@ pluginManagement {
         maven {
             // RetroFuturaGradle
             name 'GTNH Maven'
-            //noinspection HttpUrlsUsage
-            url 'http://jenkins.usrv.eu:8081/nexus/content/groups/public/'
-            allowInsecureProtocol = true
+            url 'https://nexus.gtnewhorizons.com/repository/public/'
             //noinspection GroovyAssignabilityCheck
             mavenContent {
                 includeGroup 'com.gtnewhorizons'
@@ -19,9 +17,9 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.diffplug.blowdryerSetup' version '1.6.0'
+    id 'com.diffplug.blowdryerSetup' version '1.7.1'
     // Automatic toolchain provisioning
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 blowdryerSetup {


### PR DESCRIPTION
Changes in this PR is basically the minimum required change for building on Java 25 to work. Optional changes, like `gradle wrapper` and updating other gradle plugins, are not included.