### PR TITLE
add `wheelShiftRequirement` config

### DIFF
--- a/src/main/java/yalter/mousetweaks/MTConfig.java
+++ b/src/main/java/yalter/mousetweaks/MTConfig.java
@@ -24,8 +24,8 @@ public class MTConfig {
     public static boolean wheelTweak = true;
 
     @Config.Comment("Additional key requirement for Wheel tweak to activate. None = no requirement, Shift = must holding shift, No Shift = must not holding shift.")
-    @Config.Name("Wheel tweak requirement")
-    public static WheelTweakRequirement wheelTweakRequirement = WheelTweakRequirement.NONE;
+    @Config.Name("Wheel tweak shift requirement")
+    public static WheelShiftRequirement wheelShiftRequirement = WheelShiftRequirement.NONE;
 
     @Config.Comment("How to pick the source slot when pulling items via scrolling.")
     @Config.Name("Wheel tweak search order")
@@ -179,7 +179,7 @@ public class MTConfig {
         }
     }
 
-    public enum WheelTweakRequirement {
+    public enum WheelShiftRequirement {
         NONE,
         SHIFT,
         NO_SHIFT;

--- a/src/main/java/yalter/mousetweaks/MTConfig.java
+++ b/src/main/java/yalter/mousetweaks/MTConfig.java
@@ -1,6 +1,7 @@
 package yalter.mousetweaks;
 
 import net.minecraftforge.common.config.Config;
+import org.lwjgl.input.Keyboard;
 import yalter.mousetweaks.util.Constants;
 
 @Config(modid = Constants.MOD_ID)
@@ -21,6 +22,10 @@ public class MTConfig {
     @Config.Comment("Scroll over items to move them between inventories.")
     @Config.Name("Wheel tweak")
     public static boolean wheelTweak = true;
+
+    @Config.Comment("Additional key requirement for Wheel tweak to activate. None = no requirement, Shift = must holding shift, No Shift = must not holding shift.")
+    @Config.Name("Wheel tweak requirement")
+    public static WheelTweakRequirement wheelTweakRequirement = WheelTweakRequirement.NONE;
 
     @Config.Comment("How to pick the source slot when pulling items via scrolling.")
     @Config.Name("Wheel tweak search order")
@@ -171,6 +176,20 @@ public class MTConfig {
         @Override
         public String toString() {
             return this.getValue();
+        }
+    }
+
+    public enum WheelTweakRequirement {
+        NONE,
+        SHIFT,
+        NO_SHIFT;
+
+        public boolean check() {
+            return switch (this) {
+                case NONE -> true;
+                case SHIFT -> Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+                case NO_SHIFT -> !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) && !Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+            };
         }
     }
 }

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -87,7 +87,7 @@ public class Main {
                 disableForThisContainer = handler.isMouseTweaksDisabled();
                 disableWheelForThisContainer = handler.isWheelTweakDisabled();
 
-                if (MTConfig.wheelTweak && !disableWheelForThisContainer && MTConfig.wheelTweakRequirement.check()) Mouse.getDWheel(); // reset the mouse wheel delta
+                if (MTConfig.wheelTweak && !disableWheelForThisContainer && MTConfig.wheelShiftRequirement.check()) Mouse.getDWheel(); // reset the mouse wheel delta
 
                 MTLog.logger.debug("Handler: "
                         + handler.getClass().getSimpleName()
@@ -205,7 +205,7 @@ public class Main {
     }
 
     private static void handleWheel(Slot selectedSlot) {
-        if (!MTConfig.wheelTweak || disableWheelForThisContainer || !MTConfig.wheelTweakRequirement.check())
+        if (!MTConfig.wheelTweak || disableWheelForThisContainer || !MTConfig.wheelShiftRequirement.check())
             return;
         int wheel = mouseState.consumeScrollAmount();
 

--- a/src/main/java/yalter/mousetweaks/Main.java
+++ b/src/main/java/yalter/mousetweaks/Main.java
@@ -87,7 +87,7 @@ public class Main {
                 disableForThisContainer = handler.isMouseTweaksDisabled();
                 disableWheelForThisContainer = handler.isWheelTweakDisabled();
 
-                if (MTConfig.wheelTweak && !disableWheelForThisContainer) Mouse.getDWheel(); // reset the mouse wheel delta
+                if (MTConfig.wheelTweak && !disableWheelForThisContainer && MTConfig.wheelTweakRequirement.check()) Mouse.getDWheel(); // reset the mouse wheel delta
 
                 MTLog.logger.debug("Handler: "
                         + handler.getClass().getSimpleName()
@@ -205,7 +205,7 @@ public class Main {
     }
 
     private static void handleWheel(Slot selectedSlot) {
-        if (!MTConfig.wheelTweak || disableWheelForThisContainer)
+        if (!MTConfig.wheelTweak || disableWheelForThisContainer || !MTConfig.wheelTweakRequirement.check())
             return;
         int wheel = mouseState.consumeScrollAmount();
 


### PR DESCRIPTION
Useful for items with custom wheel handler, e.g. scroll tooltip with Shift+Wheel, or change selected item when scrolling over a backpack-like container.